### PR TITLE
Fix the bug of get_integer_base_type to get the size of long long.

### DIFF
--- a/dwarf_prototypes.c
+++ b/dwarf_prototypes.c
@@ -190,7 +190,7 @@ static bool get_integer_base_type(enum arg_type *type, int byte_size,
 		return true;
 	}
 
-	if (byte_size == sizeof(long)) {
+	if (byte_size == sizeof(long long)) {
 		*type = is_signed ? ARGTYPE_LONG : ARGTYPE_ULONG;
 		return true;
 	}


### PR DESCRIPTION
On 32-bit systems, the size of longlong is 8 and long is 4 (same as int).
When the type of variable is long long, an error occurred because the ltrace code cant't handle a variable of length 8.
Change "sizeof(long)" to "sizeof(long long)" to solve this problem.

Signed-off-by: Wang Mingyu <wangmy@cn.fujitsu.com>